### PR TITLE
Added outputs for road curve length, and grade percentage

### DIFF
--- a/Src/PrecisionEngineering/Data/Calculations/Guides.cs
+++ b/Src/PrecisionEngineering/Data/Calculations/Guides.cs
@@ -195,7 +195,7 @@ namespace PrecisionEngineering.Data.Calculations
                 var dist = Vector3.Distance(guideLine.Origin.Flatten(), guideLine.Intersect.Flatten());
                 var pos = Vector3Extensions.Average(guideLine.Origin, guideLine.Intersect);
 
-                measurements.Add(new DistanceMeasurement(dist, pos, true, guideLine.Origin, guideLine.Intersect, float.NaN,
+                measurements.Add(new DistanceMeasurement(dist, pos, true, guideLine.Origin, guideLine.Intersect, null,
                     MeasurementFlags.HideOverlay | MeasurementFlags.Guide));
             }
         }

--- a/Src/PrecisionEngineering/Data/Calculations/Guides.cs
+++ b/Src/PrecisionEngineering/Data/Calculations/Guides.cs
@@ -195,7 +195,7 @@ namespace PrecisionEngineering.Data.Calculations
                 var dist = Vector3.Distance(guideLine.Origin.Flatten(), guideLine.Intersect.Flatten());
                 var pos = Vector3Extensions.Average(guideLine.Origin, guideLine.Intersect);
 
-                measurements.Add(new DistanceMeasurement(dist, pos, true, guideLine.Origin, guideLine.Intersect,
+                measurements.Add(new DistanceMeasurement(dist, pos, true, guideLine.Origin, guideLine.Intersect, float.NaN,
                     MeasurementFlags.HideOverlay | MeasurementFlags.Guide));
             }
         }

--- a/Src/PrecisionEngineering/Data/DistanceMeasurement.cs
+++ b/Src/PrecisionEngineering/Data/DistanceMeasurement.cs
@@ -5,13 +5,14 @@ namespace PrecisionEngineering.Data
     internal class DistanceMeasurement : Measurement
     {
         public DistanceMeasurement(float length, Vector3 position, bool isStraight, Vector3 startPosition,
-            Vector3 endPosition, MeasurementFlags flags)
+            Vector3 endPosition, float curvatureRadius, MeasurementFlags flags)
             : base(position, flags)
         {
             Length = length;
             IsStraight = isStraight;
             StartPosition = startPosition;
             EndPosition = endPosition;
+            CurvatureRadius = curvatureRadius;
         }
 
         /// <summary>
@@ -33,6 +34,11 @@ namespace PrecisionEngineering.Data
         /// End position of the distance measurement.
         /// </summary>
         public Vector3 EndPosition { get; }
+
+        /// <summary>
+        /// Radius of curvature at the point
+        /// </summary>
+        public float CurvatureRadius { get; }
 
         /// <summary>
         /// Difference in height between the StartPosition and EndPosition.

--- a/Src/PrecisionEngineering/Data/DistanceMeasurement.cs
+++ b/Src/PrecisionEngineering/Data/DistanceMeasurement.cs
@@ -5,7 +5,7 @@ namespace PrecisionEngineering.Data
     internal class DistanceMeasurement : Measurement
     {
         public DistanceMeasurement(float length, Vector3 position, bool isStraight, Vector3 startPosition,
-            Vector3 endPosition, float curvatureRadius, MeasurementFlags flags)
+            Vector3 endPosition, float? curvatureRadius, MeasurementFlags flags)
             : base(position, flags)
         {
             Length = length;
@@ -38,7 +38,7 @@ namespace PrecisionEngineering.Data
         /// <summary>
         /// Radius of curvature at the point
         /// </summary>
-        public float CurvatureRadius { get; }
+        public float? CurvatureRadius { get; }
 
         /// <summary>
         /// Difference in height between the StartPosition and EndPosition.

--- a/Src/PrecisionEngineering/Data/Measurement.cs
+++ b/Src/PrecisionEngineering/Data/Measurement.cs
@@ -35,7 +35,12 @@ namespace PrecisionEngineering.Data
         /// Indicate that this measurement is used for snapping and should be visable when
         /// snapping is enabled.
         /// </summary>
-        Snap = 1 << 6
+        Snap = 1 << 6,
+
+        /// <summary>
+        /// Indicate that this measurement should include a grade readout.
+        /// </summary>
+        Grade = 1 << 7,
     }
 
     internal abstract class Measurement

--- a/Src/PrecisionEngineering/Data/PrecisionCalculator.cs
+++ b/Src/PrecisionEngineering/Data/PrecisionCalculator.cs
@@ -103,7 +103,7 @@ namespace PrecisionEngineering.Data
                 if (netTool.ControlPointsCount == 1) //it's straight.
                     flags |= MeasurementFlags.Grade;
 
-                measurements.Add(new DistanceMeasurement(dist, pos, true, p1, p2, float.NaN, flags));
+                measurements.Add(new DistanceMeasurement(dist, pos, true, p1, p2, null, flags));
             }
         }
 
@@ -220,7 +220,7 @@ namespace PrecisionEngineering.Data
             if (found && Mathf.Sqrt(minDist) > Settings.MinimumDistanceMeasure)
             {
                 measurements.Add(new DistanceMeasurement(Vector3.Distance(p1, p), Vector3Extensions.Average(p1, p), true,
-                    p1, p, float.NaN,
+                    p1, p, null,
                     MeasurementFlags.Secondary));
             }
         }

--- a/Src/PrecisionEngineering/Manager.cs
+++ b/Src/PrecisionEngineering/Manager.cs
@@ -232,6 +232,7 @@ namespace PrecisionEngineering
                         if (Mathf.Abs(heightdiff) > 0)
                         {
                             dist += string.Format("\n(Elev: {0})", StringUtil.GetHeightMeasurementString(heightdiff));
+                            dist += string.Format("\n(Grade: {0}", (heightdiff / dm.Length).ToString("P02"));
                         }
                     }
                 }

--- a/Src/PrecisionEngineering/Manager.cs
+++ b/Src/PrecisionEngineering/Manager.cs
@@ -206,7 +206,7 @@ namespace PrecisionEngineering
             {
                 var dm = m as DistanceMeasurement;
 
-                if (Mathf.Abs(dm.Length) < Settings.MinimumDistanceMeasure && (float.IsNaN(dm.CurvatureRadius) || !_secondaryDetailEnabled))
+                if (Mathf.Abs(dm.Length) < Settings.MinimumDistanceMeasure && (!dm.CurvatureRadius.HasValue || !_secondaryDetailEnabled))
                 {
                     return;
                 }
@@ -241,12 +241,12 @@ namespace PrecisionEngineering
                         }
                     }
                 }
-                if (_secondaryDetailEnabled && !float.IsNaN(dm.CurvatureRadius))
+                if (_secondaryDetailEnabled && dm.CurvatureRadius.HasValue)
                 {
                     //We only need to add a newline if there's already text in there.
                     if (dist.Length > 0)
                         dist += "\n";
-                    dist += string.Format("(Radius: {0})", StringUtil.GetDistanceMeasurementString(dm.CurvatureRadius, _secondaryDetailEnabled));
+                    dist += string.Format("(Radius: {0})", StringUtil.GetDistanceMeasurementString(dm.CurvatureRadius.Value, _secondaryDetailEnabled));
                 }
 
 

--- a/Src/PrecisionEngineering/Manager.cs
+++ b/Src/PrecisionEngineering/Manager.cs
@@ -220,6 +220,11 @@ namespace PrecisionEngineering
                 if ((dm.Flags & MeasurementFlags.Height) != 0)
                 {
                     dist = string.Format("H: {0}", StringUtil.GetHeightMeasurementString(dm.Length));
+                    if (_secondaryDetailEnabled && !float.IsNaN(dm.CurvatureRadius))
+                    {
+                        dist += string.Format("\n(Radius: {0}", StringUtil.GetDistanceMeasurementString(dm.CurvatureRadius, _secondaryDetailEnabled));
+                    }
+
                 }
                 else
                 {
@@ -233,6 +238,10 @@ namespace PrecisionEngineering
                         {
                             dist += string.Format("\n(Elev: {0})", StringUtil.GetHeightMeasurementString(heightdiff));
                             dist += string.Format("\n(Grade: {0}", (heightdiff / dm.Length).ToString("P02"));
+                        }
+                        if(!float.IsNaN(dm.CurvatureRadius))
+                        {
+                            dist += string.Format("\n(Radius: {0}", StringUtil.GetDistanceMeasurementString(dm.CurvatureRadius, _secondaryDetailEnabled));
                         }
                     }
                 }


### PR DESCRIPTION
This still needs  some refining in terms of output, but it's working well enough as-is.

So far this changes adds two things to the tool:

The first is it estimates the arc length of a segment being built. I tested that it's accurate for quadrants of a circle, at least, but barring finding out what's the formula for how Skylines decides the road bezier tangents, it works well enough.

The second thing, which depends on the first, is displaying the road grade, as a percentage. Currently it does it on every length measurement, which looks messy, so I might change it so it only shows up on the measurements for the road length, and not for the guidelines.

One more thing that I'd like to do is also show the radius of curvature at each end of the segment.

These additions assist in building networks that follow real-world limits to slope and curve radius.